### PR TITLE
Updated comment workflow based on guthub rec

### DIFF
--- a/.github/workflows/pull_request_post_processor.yml
+++ b/.github/workflows/pull_request_post_processor.yml
@@ -1,0 +1,46 @@
+name: Comment on pull request post procesing
+# depends on and only executes after pull_request_processor.yml is complete
+
+on: 
+    workflow_run:
+    workflows: ["Pull Request Processor"]
+    types:
+      - completed
+
+jobs:
+  one:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.8]
+    if: >
+      ${{ github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: 'Download artifact'
+        uses: actions/github-script@v3.1.0
+        with:
+          script: |
+            var artifacts = await github.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: ${{github.event.workflow_run.id }},
+            });
+            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "prcontext"
+            })[0];
+            var download = await github.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            var fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/pr.zip', Buffer.from(download.data));
+      - run: unzip pr.zip
+
+      - name: Comment on pull request
+        run: |
+          ls
+          
+      

--- a/.github/workflows/pull_request_post_processor.yml
+++ b/.github/workflows/pull_request_post_processor.yml
@@ -2,10 +2,10 @@ name: Comment on pull request post procesing
 # depends on and only executes after pull_request_processor.yml is complete
 
 on: 
-    workflow_run:
-    workflows: ["Pull Request Processor"]
-    types:
-      - completed
+  workflow_run:
+  workflows: ["Pull Request Processor"]
+  types:
+    - completed
 
 jobs:
   one:

--- a/.github/workflows/pull_request_processor.yml
+++ b/.github/workflows/pull_request_processor.yml
@@ -1,12 +1,15 @@
-name: Hello message on pull request.
+name: Pull Request Processor
 # https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#github-context
-# the pull request target event provides RW token to github 
+# The pull request target event provides RW token to github 
 # https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/
-# pull_request_target is only raised when a pull request is raised from a fork
-# https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+# But `on: pull_request_target` should be avoided due to security
+# reasons. Read more: [SEC_ADV_1] https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+# 
+# We will use a mix of github pull_request that does not provide any write access to pull requests on forks
+# and workflow event, as discussed in [SEC_ADV_1]
 
 on: 
-  pull_request_target:
+  pull_request:
     branches:
       - main
 
@@ -40,14 +43,8 @@ jobs:
           cat ./.tmp/github.json
           echo "commit details: "
           cat ./.tmp/commitDetails.json
-      - name: Comment on pull request
-        run: |
-          pip install PyGithub
-          which git
-          if ! python ./.github/workflows/python/pull_request_comment.py; then
-              echo "Pull request details could not be extracted"
-              exit 1
-          else
-              echo "all good"
-          fi
+      - uses: actions/upload-artifact@v2
+        with:
+          name: prcontext
+          path: .tmp/
       


### PR DESCRIPTION
Updated comment workflow based on GitHub rec

 https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/
 But `on: pull_request_target` should be avoided due to security
 reasons. Read more: [SEC_ADV_1] https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
 
 We will use a mix of github pull_request that does not provide any write access to pull requests on forks
 and workflow event, as discussed in [SEC_ADV_1]
